### PR TITLE
fix: cypress now defaults to chrome for testing in the Action file

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           build: yarn run build
           start: yarn start
+          browser: chrome
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Action file now specifically uses Chrome as a browser for testing, due to the presence of MetaMask during installation that can block with Electron browser.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
