### PR TITLE
feat: add git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+static/dist/** linguist-generated
+*.lockb linguist-generated
+*.lock linguist-generated


### PR DESCRIPTION
Resolves https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/275
Related to #29 

This will prevent maxing out rewards due to change from `yarn.lock` to `bun.lock`, we should also add this to the template.