### PR TITLE
chore: add Deno Deploy workflow

### DIFF
--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy (Deno Deploy)
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
+    secrets: inherit
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      FRONTEND_URL: https://onboard.ubq.fi
+      STATIC_DIR: static/dist
+    with:
+      project: onboard-ubq-fi
+      preview_project: onboard-ubq-fi-preview
+      entrypoint: serve.ts
+      install_command: |
+        bun install
+      build_command: |
+        bun run build
+      env_var_keys: |
+        SUPABASE_URL
+        SUPABASE_ANON_KEY
+        FRONTEND_URL
+        STATIC_DIR
+      bun_version: "1.1.x"
+      deno_version: v2.x
+      deployctl_version: "1.12.0"
+      prod_branch: development
+      include: |
+        static/**
+        build/**
+      exclude: |
+        node_modules
+        tests
+        cypress

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -9,11 +9,6 @@ jobs:
   deploy:
     uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
     secrets: inherit
-    env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-      FRONTEND_URL: https://onboard.ubq.fi
-      STATIC_DIR: static/dist
     with:
       project: onboard-ubq-fi
       preview_project: onboard-ubq-fi-preview
@@ -22,18 +17,20 @@ jobs:
         bun install
       build_command: |
         bun run build
-      env_var_keys: |
-        SUPABASE_URL
-        SUPABASE_ANON_KEY
-        FRONTEND_URL
-        STATIC_DIR
+      build_env: |
+        SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+        SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
+        FRONTEND_URL=https://onboard.ubq.fi
+      runtime_env: |
+        SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+        SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
+        FRONTEND_URL=https://onboard.ubq.fi
       bun_version: "1.1.x"
       deno_version: v2.x
       deployctl_version: "1.12.0"
       prod_branch: development
       include: |
         static/**
-        build/**
       exclude: |
         node_modules
         tests

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -21,12 +21,8 @@ jobs:
         SUPABASE_URL=${{ secrets.SUPABASE_URL }}
         SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
         FRONTEND_URL=https://onboard.ubq.fi
-      runtime_env: |
-        SUPABASE_URL=${{ secrets.SUPABASE_URL }}
-        SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
-        FRONTEND_URL=https://onboard.ubq.fi
-      bun_version: "1.1.x"
-      deno_version: v2.x
+      bun_version: "1.2.x"
+      deno_version: 2.x
       deployctl_version: "1.12.0"
       prod_branch: development
       include: |

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "serve": "deno run --allow-read --allow-net serve.ts"
+    "serve": "deno run --allow-read --allow-net --allow-env serve.ts"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "serve": "deno run --allow-read --allow-net serve.ts"
+  }
+}

--- a/serve.ts
+++ b/serve.ts
@@ -1,0 +1,5 @@
+import { serveDir } from "https://deno.land/std@0.224.0/http/file_server.ts";
+
+const root = Deno.env.get("STATIC_DIR") ?? "static/dist";
+
+Deno.serve((req) => serveDir(req, { fsRoot: root, quiet: true }));

--- a/serve.ts
+++ b/serve.ts
@@ -1,5 +1,5 @@
-import { serveDir } from "https://deno.land/std@0.224.0/http/file_server.ts";
+import { serveDir } from "jsr:@std/http/file-server";
 
-const root = Deno.env.get("STATIC_DIR") ?? "static/dist";
+const root = Deno.env.get("STATIC_DIR") ?? "static";
 
 Deno.serve((req) => serveDir(req, { fsRoot: root, quiet: true }));


### PR DESCRIPTION
## Summary
- add shared serve.ts + deno.json for Deno Deploy static hosting
- wire reusable org-level workflow with Supabase envs and static/dist output

Resolves https://github.com/ubiquity/deno-deploy-workflow/issues/1

## Testing
- not run (CI will build/deploy)
